### PR TITLE
Remove remaining lower case conformance language key words

### DIFF
--- a/docs/Controller Guide.md
+++ b/docs/Controller Guide.md
@@ -1,6 +1,7 @@
 # NMOS Controller Implementation Guide
 
 ## Scope
+
 This document is intended as a guide for implementers or users of Controllers within NMOS-enabled networked media systems. The document defines what a Controller is and outlines the requirements of a Controller with respect to each existing NMOS specification through references to the relevant sections of those documents.
 
 The document focuses primarily on guidance for the following NMOS specifications:
@@ -11,9 +12,11 @@ The document focuses primarily on guidance for the following NMOS specifications
 However, this is a living document and it is intended that fuller guidance for other NMOS specifications be added in future.
 
 ## Use of Normative Language
-This document is a guide to Controllers only and not a specification itself. It provides informational guidance around the normative requirements of the relevant specifications. If there are any inconsistencies between this guide and the specifications then, unequivocally, the specification is correct. Any normative language key words found in this document are not to be interpreted as RFC 2119 key words.
+
+This document is a guide to Controllers only and not a specification itself. It provides informational guidance around the normative requirements of the relevant specifications. If there are any inconsistencies between this guide and the specifications then, unequivocally, the specification is correct. Any conformance language key words found in this document are not to be interpreted as RFC 2119 key words.
 
 ## Controller Definition
+
 A Controller is Client software that interacts with the NMOS APIs to discover, connect and manage devices within a networked media system. The diagram below shows some of those API interactions with other NMOS system components. 
 
 ![Role of NMOS Controller in a Networked Media System](./images/NMOS_Controller.svg)
@@ -25,9 +28,11 @@ Where a Controller is additionally acting as an Node (e.g. receiving monitoring 
 This guide and the associated NMOS specifications often refer to the "user" of a Controller. This includes both human operators who drive the Controller manually and automation systems that drive the Controller programmatically.
 
 ## Controller Interactions
+
 The sections below describe how Controllers interact with the NMOS suite of Interface Specifications (IS) and Best Current Practice (BCP) recommendations, with references to the relevant parts of these specifications where the normative language can be found. They also include some additional informative guidance to implementers of Controllers.
 
 ### Notes on Understanding the AMWA NMOS Specifications
+
 All of the specifications referenced below can be accessed from the [AMWA NMOS](https://specs.amwa.tv/nmos/) website.
 
 As well as reading the text of the specifications, a fuller understanding of the described API can be achieved by paying particular attention to the API section (for instance, the [IS-04 Query API](https://specs.amwa.tv/is-04/releases/v1.3.1/APIs/QueryAPI.html)).
@@ -40,6 +45,7 @@ These, along with the provided JSON schemas and examples, often contain canonica
 Similarly be aware of the [NMOS Parameter Registers](https://specs.amwa.tv/nmos-parameter-registers/) as this contains definitions used by many of the specifications.
 
 ### IS-04 Discovery and Registration
+
 > *Controllers use the **IS-04 Query API** to discover and obtain updates on the NMOS resources that are available on the network.*
 
 The IS-04 specification describes the mechanism for the discovery and registration of NMOS resources within a media network. It comprises three APIs: the Registration API, the Query API and the Node API. A brief summary of each API is given below.
@@ -55,15 +61,16 @@ The **IS-04 Node API** is exposed by Nodes. It is used by Controllers or other N
 The IS-04 specification describes the requirements for Controllers in the document entitled [Controllers](https://github.com/AMWA-TV/is-04/blob/nmos-controller/docs/Controllers.md) (link to be updated after IS-04 PR accepted).
 
 ### IS-05 Device Connection Management
+
 > *Controllers use the **IS-05 Connection API** to make connections between Senders and Receivers.*
 
-Nodes on a media network may contain one or more Devices, each of which may include any number of Senders and Receivers. The IS-05 specification describes the mechanism for making connections between Senders and Receivers.
+Nodes on a media network can provide any number of Devices, each of which can have any number of Senders and Receivers. The IS-05 specification describes the mechanism for making connections between Senders and Receivers.
 
 The **IS-05 Connection API** is exposed by NMOS Devices. Controllers discover the URL of the Connection API through the list of `controls` for the Device. This is part of the information that will have been registered to the IS-04 Registry by the Device's parent Node. It is available to the Controller by querying the Registry using the IS-04 Query API and examining the information returned about the Device in question. 
 
-Controllers make connections between Senders and Receivers by making calls to the Connection APIs of their parent Devices.
+Controllers make connections between Senders and Receivers by making requests to the Connection APIs of their parent Devices.
 
-As an example, for RTP-based connections this involves the following two steps. The Controller first calls the Connection API for the Sender to update its transport parameters as required and then obtain its transport file. It then calls the Connection API for the Receiver to provide it with the transport file and complete the connection.
+As an example, for RTP-based connections this involves the following two steps. The Controller first calls the Connection API for the Sender to update its transport parameters if necessary and then obtain its transport file. It then calls the Connection API for the Receiver to provide it with the transport file and complete the connection.
 
 Note that some other types of connection such as WebSocket or MQTT follow a similar pattern but do not use transport files.
 
@@ -72,21 +79,27 @@ Note that some other types of connection such as WebSocket or MQTT follow a simi
 The IS-05 specification describes the requirements for Controllers in the document entitled [Controllers](https://github.com/jonathan-r-thorpe/is-05/blob/jonathan-r-thorpe-nmos-controller/docs/Controllers.md) (link to be updated after IS-05 PR accepted).
 
 ### IS-07 Event and Tally
+
 > *Controllers are able to identify **IS-07** Senders and Receivers in the **IS-04** Registry and make connections between them using **IS-05**.*
 
 ### IS-08 Audio Channel Mapping
+
 > *Controllers use the **IS-08 Channel Mapping API** to indicate the current mapping of audio channel inputs to outputs within a device and allow a user of the Controller to modify these.*
 
 ### IS-09 System Parameters
+
 > *Controllers use the **IS-09 System API** to obtain information about the location of system logging servers to which they are able to post their logs.*
 
 ### IS-10 Authorization
+
 > *Controllers use the **IS-10 Authorization API** to enable them to make authorized calls to all other APIs.*
 
 ### BCP-002-01 Natural Grouping
+
 > *Controllers use the **BCP-002-01 Natural Grouping** best current practice recommendations to allow them to understand associations between logical groups of NMOS Senders or Receivers.*
 
 ### BCP-003-01 Secure Communications in NMOS Systems
+
 > *Controllers use the **BCP-003-01 Secure Communications in NMOS Systems** best current practice recommendations to protect the API calls that they make with transport layer security.*
 
 The NMOS APIs use the HTTP and WebSocket protocols to exchange information between different components of a media network. However, unless a method of securing these communications is used, all information exchanged using the NMOS APIs is sent as plaintext. This means there is a risk that the information is intercepted and read by a third party. It is even possible that the information is modified without the knowledge of the original communicating parties. These types of person-in-the-middle attacks can be prevented by using standard IT best practices to ensure that the communication channel is secure.
@@ -98,10 +111,13 @@ In particular, the document specifies the Transport Layer Security (TLS) version
 To aid implementers, requirements that are specific to Controllers have been set out in the [Controllers](https://github.com/jonathan-r-thorpe/bcp-003-01/blob/jonathan-r-thorpe-nmos-controller/docs/Controllers.md) section of the BCP-003-01 document. (Link to be updated after BCP-003-01 PR accepted).
 
 ### BCP-003-02 Authorization in NMOS Systems
+
 > *Controllers use the **BCP-003-02 Authorization in NMOS Systems** best current practice recommendations to ensure they meet the authorization requirements of the endpoints to which they are making API calls.*
 
 ### BCP-003-03 Certificate Provisioning in NMOS Systems
+
 > *Controllers use the **BCP-003-03 Certificate Provisioning in NMOS Systems** best current practice recommendations to obtain and refresh Client certificates for **BCP-003-01** transport layer security.*
 
 ### BCP-004-01 Receiver Capabilities
+
 > *Controllers use the **BCP-004-01 Receiver Capabilities** best current practice recommendations to determine whether a Receiver is capable of receiving a Flow from a Sender.*


### PR DESCRIPTION
Seemed easy to reword remaining instances of "may" and "required" so why not?

Also tweaked "Nodes on a media network may contain _one or more_ Devices" to "_any number of_ Devices" since the minimum required data model is just a Node resource, e.g. for a Node that simply wants to advertise some `services`.

Also changed one instance of API "calls" to "requests"... there are a lot more "calls"...